### PR TITLE
Fixed data type passed into API to an object

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.jsx
+++ b/frontend/src/pages/SignUp/SignUp.jsx
@@ -24,7 +24,7 @@ export default function SignUp() {
     const handleSignUp = async (e) => {
         e.preventDefault();
         try {
-            const data = await registerUser(
+            const data = await registerUser({
                 name,
                 email,
                 password,
@@ -34,7 +34,7 @@ export default function SignUp() {
                 classification,
                 description,
                 bio,
-                availability);
+                availability});
 
             setUser(data);
             navigate('/auth/login');


### PR DESCRIPTION
## Description

### Context
This PR is fixing an error in the SignUp page ordinary variable are being passed to the `registerUser` API function in `dataService.js`, but it is expecting an object.

###Future PRs
- Fix errors in the frontend.
- Create many error handling messages for the users.

## Milestones
Milestone 1

## Test Plan
Run this on the terminal for both frontend and backend.
```bash
npm run dev
```
**Before**: The database wouldn't take in any data nor would the create account button work.
**After**: Accounts can now be created.