### PR TITLE
Frontend & Backend Implementation to End  a Connection 

### DIFF
--- a/backend/controllers/mentorshipController.js
+++ b/backend/controllers/mentorshipController.js
@@ -65,6 +65,34 @@ const updateMentorship = async (req, res) => {
     }
 }
 
+const endMentorship = async (req, res) => {
+    const connectionId = parseInt(req.params.connectionId);
+    try {
+        const connection = await prisma.mentorship.findUnique({
+            where: { id: connectionId },
+            select: { mentorId: true, menteeId: true }
+        });
+        if (!connection) {
+            return res.status(404).json({ error: "Mentorship not found" });
+        }
+
+        const { menteeId, mentorId } = connection;
+
+        const request = await prisma.request.findFirst({
+            where: { menteeId, mentorId }
+        })
+        await prisma.mentorship.delete({ where: { id: connectionId } });
+
+        if (request) {
+            await prisma.request.delete({ where: { id: request.id } });
+        }
+        res.status(204).send();
+    } catch (err) {
+        console.error(err);
+        res.status(404).json({ error: "Failure ending connection" });
+    }
+}
+
 const requestConnection = async (req, res) => {
     const { menteeId, mentorId } = req.body;
     try {
@@ -98,5 +126,6 @@ module.exports = {
     requestConnection,
     updateRequestStatus,
     createMentorship,
-    updateMentorship
+    updateMentorship,
+    endMentorship
 };

--- a/backend/routes/mentorshipRoutes.js
+++ b/backend/routes/mentorshipRoutes.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const { getMentors, pendingRequests, removeRequest } = require('../controllers/menteeController');
-const { getAllConnections, requestConnection, updateRequestStatus, createMentorship, updateMentorship } = require('../controllers/mentorshipController');
+const { getAllConnections, requestConnection, updateRequestStatus, createMentorship, updateMentorship, endMentorship } = require('../controllers/mentorshipController');
 const { getMenteeRequests } = require('../controllers/mentorController');
 const isAuthenticated = require('../middlewares/isAuthenticated');
 
@@ -13,5 +13,6 @@ router.post('/connected', isAuthenticated, createMentorship);
 router.patch('/connected/update', isAuthenticated, updateMentorship);
 router.get('/pending', isAuthenticated, pendingRequests);
 router.delete('/request/remove/:requestId', isAuthenticated, removeRequest);
+router.delete('/connection/remove/:connectionId', isAuthenticated, endMentorship);
 
 module.exports = router;

--- a/frontend/src/components/ConnectionsList/ConnectionCard.jsx
+++ b/frontend/src/components/ConnectionsList/ConnectionCard.jsx
@@ -2,7 +2,7 @@ import { AiFillDelete } from "react-icons/ai";
 import { RxAvatar } from "react-icons/rx";
 import "./ConnectionCard.css"
 
-export default function ConnectionCard({ person }) {
+export default function ConnectionCard({ person, endConnection }) {
     return (
         <div className="connection-card">
             <div className="connection-top">
@@ -18,7 +18,7 @@ export default function ConnectionCard({ person }) {
             <hr className="divider" />
 
             <div className="connection-actions">
-                <button className="end-btn"><AiFillDelete /></button>
+                <button onClick={endConnection} className="end-btn"><AiFillDelete /></button>
             </div>
         </div>
     )

--- a/frontend/src/components/ConnectionsList/ConnectionList.jsx
+++ b/frontend/src/components/ConnectionsList/ConnectionList.jsx
@@ -1,8 +1,17 @@
 import ConnectionCard from "./ConnectionCard";
+import { endMentorship } from "../../services/mentorshipService";
 import "./ConnectionList.css"
 
-export default function ConnectionList({ connections, role }) {
+export default function ConnectionList({ connections, setConnections, role }) {
 
+    const handleEnd = async (connectionId) => {
+        try {
+            await endMentorship(connectionId);
+            setConnections(connections.filter(connection => connection.id !== connectionId));
+        } catch (err) {
+            console.error("Error ending connection");
+        }
+    }
 
     return (
         <div className="list-container">
@@ -12,6 +21,7 @@ export default function ConnectionList({ connections, role }) {
                     <ConnectionCard
                         key={connectionUser.id}
                         person={connectionUser}
+                        endConnection={() => handleEnd(connection.id)}
                     />
                 );
             })}

--- a/frontend/src/pages/Connections/Connections.jsx
+++ b/frontend/src/pages/Connections/Connections.jsx
@@ -23,7 +23,10 @@ export default function Connections() {
             <h2 className="connections-count">{connections.length} Connections</h2>
             <div className="connections-content">
                 <div className="connections-left">
-                    <ConnectionList connections={connections} role={user.role} />
+                    <ConnectionList
+                        connections={connections}
+                        setConnections={setConnections}
+                        role={user.role} />
                 </div>
             </div>
         </div>

--- a/frontend/src/services/mentorshipService.js
+++ b/frontend/src/services/mentorshipService.js
@@ -21,3 +21,13 @@ export const createMentorship = async (menteeId, mentorId) => {
         throw err;
     }
 }
+
+export const endMentorship = async (connectionId) => {
+    try {
+        const response = await mentorship.delete(`/connection/remove/${connectionId}`);
+        return response.data;
+    } catch (err) {
+        console.error("Error ending connection", err);
+        throw err;
+    }
+}


### PR DESCRIPTION
## Description

This PR  functionality for the delete button on the connections. When clicked it deletes the connection record and also the request. Mentor returns to the list of available mentors on mentee's homepage.
 
**Reference**: [Project Process Details](https://docs.google.com/document/d/1IS9PjGo6bTUraB12VwymkuySsonx-MDjSDm_PT7BrwI/edit?tab=t.0#heading=h.ifvl8ma0rodg)

### Context 
- Added a controller function that gets the connectionId and find the request that is associated with the connection, then deletes both record.
- On the frontend, added a function that sends `delete` request to the backend.
- Implemented the end connection handler function logic in the `ConnectionList` component.

## Milestones
This PR concludes milestone 3.

## Test Plan
**Run both frontend and backend**
```
npm run dev
```
**Mentee Login Details**
```text
Email: jordan.kim@menlo.edu
Password: pass1234
```
### Test Artifact
- Video demonstrates deleting a connection and it appearing on mentee's home page 

https://github.com/user-attachments/assets/33ebf8b5-f3d8-4b71-b5c5-301b6d02d736