### PR TITLE
Added New Tables to Database: Availability & Session

### DIFF
--- a/backend/prisma/migrations/20250716220404_add_tables_scheduling/migration.sql
+++ b/backend/prisma/migrations/20250716220404_add_tables_scheduling/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "WeekDay" AS ENUM ('MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURDAY', 'FRIDAY');
+
+-- CreateTable
+CREATE TABLE "Availability" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "day" "WeekDay" NOT NULL,
+    "startTime" TEXT NOT NULL,
+    "endTime" TEXT NOT NULL,
+
+    CONSTRAINT "Availability_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" SERIAL NOT NULL,
+    "mentorshipId" INTEGER NOT NULL,
+    "menteeId" INTEGER NOT NULL,
+    "mentorId" INTEGER NOT NULL,
+    "reason" TEXT,
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "endTime" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Availability" ADD CONSTRAINT "Availability_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_mentorshipId_fkey" FOREIGN KEY ("mentorshipId") REFERENCES "Mentorship"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_menteeId_fkey" FOREIGN KEY ("menteeId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_mentorId_fkey" FOREIGN KEY ("mentorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,12 +26,15 @@ model User {
   classification      Classification
   bio                 String
   availability        String?
+  preference          Availability[]
   
-  interest               UserInterest[]     @relation("user")
+  interest               UserInterest[]    @relation("user")
   mentorMentorships      Mentorship[]      @relation("MentorMentorships")
   menteeMentorships      Mentorship[]      @relation("MenteeMentorships")
-  mentorRequests         Request[]      @relation("MentorRequests")
-  menteeRequests         Request[]      @relation("MenteeRequests")  
+  mentorRequests         Request[]         @relation("MentorRequests")
+  menteeRequests         Request[]         @relation("MenteeRequests")
+  MenteeSessions         Session[]         @relation("MenteeSessions")
+  MentorSessions         Session[]         @relation("MentorSessions")
 }
 
 model Mentorship {
@@ -43,6 +46,8 @@ model Mentorship {
   status              MentorshipStatus      @default(ACTIVE)
   startedAt           DateTime    @default(now()) 
   endedAt             DateTime?
+
+  mentorshipSession      Session[]
 
   @@index([mentorId])
   @@unique([menteeId, mentorId, status])
@@ -76,6 +81,28 @@ model UserInterest {
     interest            Interest    @relation("interest", fields:[interestId], references:[id])
 }
 
+model Availability {
+  id                  Int     @id       @default(autoincrement())
+  userId              Int
+  user                User     @relation(fields:[userId], references:[id])
+  day                 WeekDay
+  startTime           String
+  endTime             String
+}
+
+model Session {
+  id                 Int     @id       @default(autoincrement())
+  mentorshipId       Int
+  mentorship         Mentorship    @relation(fields: [mentorshipId], references:[id])
+  menteeId           Int
+  mentee             User    @relation("MenteeSessions", fields: [menteeId], references:[id])
+  mentorId           Int
+  mentor             User    @relation("MentorSessions", fields: [mentorId], references:[id])            
+  reason             String?
+  startTime          DateTime
+  endTime            DateTime
+}
+
 enum MentorshipStatus {
   ACTIVE
   ENDED
@@ -97,4 +124,12 @@ enum Classification {
   SOPHOMORE
   JUNIOR
   SENIOR  
+}
+
+enum WeekDay {
+  MONDAY
+  TUESDAY
+  WEDNESDAY
+  THURDAY
+  FRIDAY
 }


### PR DESCRIPTION
## Description

This PR introduces new tables to support the scheduling system between mentees and mentors.

### Context
- **Availability** table:
  - Stores week recurring availability for users
  - Includes weekday(num) and `startTime` & `endTime` as strings
  - Many-to-one relation with the `User` table.
  - Used to find free intervals when scheduling sessions
- **Session** table
   - Stores scheduled meeting between a mentor and mentee.
   - Includes `startTime`,`endTime`, and unique `id`
   - Many-to-one relation with the Connection table

These tables lay the foundation for suggesting best meeting time between connected users based on their weekly availability and existing sessions.

### Future PRs
- Implementing the functionality to calculate the best time to meet based on overlapping free times.

## Milestones
This PR works towards the completion of 5 as it lays the foundation to work on the backend controller.
