### PR TITLE
Frontend Display of Suggested Meeting Times in Schedule Tab

### DIFF
--- a/frontend/src/components/ConnectionsComp/Schedule.jsx
+++ b/frontend/src/components/ConnectionsComp/Schedule.jsx
@@ -5,8 +5,9 @@ import "./ConnectionsComp.css"
 import { MS_PER_SECOND } from "../../utils/constants";
 import { createSession } from "../../services/mentorshipService";
 import ErrorModal from "../ErrorModal/ErrorModal";
+import { formatUnixTimes } from "../../utils/formatUnixTime";
 
-export default function Schedule({ connection, upDate }) {
+export default function Schedule({ connection, timeSuggestions, upDate }) {
     const [date, setDate] = useState("");
     const [startTime, setStartTime] = useState("");
     const [endTime, setEndTime] = useState("");
@@ -84,16 +85,34 @@ export default function Schedule({ connection, upDate }) {
                 <div className="schedule-container">
                     <h2 className="schedule-title">Suggested Meeting Times</h2>
                     <p className="schedule-text">Calculated best times that match your availability</p>
-                    <div className="session">
-                        <div className="time">
-                            <AiOutlineCalendar />
-                            <h3><strong>Monday</strong></h3>
+                    {timeSuggestions.proposedSession.length > 0 ? (
+                        timeSuggestions.proposedSession.map(session => (
+                            <div className="session">
+                                <div className="time">
+                                    <AiOutlineClockCircle />
+                                    <h3><strong>{formatUnixTimes(session[0], session[1])}</strong></h3>
+                                </div>
+                            </div>
+                        ))) : (
+                        <div className="session">
+                            <h3>Reschdule To meet with mentor</h3>
+                            <div className="time">
+                                <AiOutlineClockCircle />
+                                <h3>Cancel<strong>{formatUnixTimes(timeSuggestions.resolvedSession.freedTime[0], timeSuggestions.resolvedSession.freedTime[1])}</strong></h3>
+                            </div>
+                            <h3>Rescheduling Options</h3>
+                            {timeSuggestions.resolvedSession.rescheduleTo.map(session => {
+                                <div className="session">
+                                    <div className="time">
+                                        <AiOutlineClockCircle />
+                                        <h3><strong>{formatUnixTimes(session[0], session[1])}</strong></h3>
+                                    </div>
+                                </div>
+                            })
+                            }
                         </div>
-                        <div className="time">
-                            <AiOutlineClockCircle />
-                            <p>14:00 - 15:00</p>
-                        </div>
-                    </div>
+
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/Connections/Connections.jsx
+++ b/frontend/src/pages/Connections/Connections.jsx
@@ -2,7 +2,7 @@ import { BsPeople } from "react-icons/bs";
 import { MdPeopleOutline } from "react-icons/md";
 import { GoTasklist } from "react-icons/go";
 import { AiOutlineCalendar } from "react-icons/ai";
-import { getAllConnections, getMeetingHistory, getUpcomingMeeting } from "../../services/mentorshipService";
+import { getAllConnections, getMeetingHistory, getUpcomingMeeting, suggestedSession } from "../../services/mentorshipService";
 import { useEffect, useState } from "react";
 import { useUser } from "../../contexts/UserContext";
 import ConnectionList from "../../components/ConnectionsList/ConnectionList";
@@ -19,6 +19,7 @@ export default function Connections() {
     const [selectedConnection, setSelectedConnection] = useState(null);
     const [upComing, setUpcoming] = useState([]);
     const [meetingHistory, setMeetingHistory] = useState([]);
+    const [timeSuggestions, setTimeSuggestions] = useState([])
     const { user } = useUser();
 
     useEffect(() => {
@@ -32,8 +33,10 @@ export default function Connections() {
         setSelectedConnection(connection);
         const historyData = await getMeetingHistory(connection.id);
         const upComingData = await getUpcomingMeeting(connection.id);
+        const sessionsData = await suggestedSession(connection.mentor.id);
         setUpcoming(upComingData);
         setMeetingHistory(historyData);
+        setTimeSuggestions(sessionsData);
     }
 
     return (
@@ -93,7 +96,7 @@ export default function Connections() {
                             <div className="right-content">
                                 {activeTab === 'Meetings' && (<Meetings upComing={upComing} meetingHistory={meetingHistory} connection={selectedConnection} />)}
                                 {activeTab === 'Tasks' && (<Tasks />)}
-                                {activeTab === 'Schedule' && (<Schedule connection={selectedConnection} upDate={handleSelect} />)}
+                                {activeTab === 'Schedule' && (<Schedule connection={selectedConnection} timeSuggestions={timeSuggestions} upDate={handleSelect} />)}
                             </div>
                         </div> :
                         <div className="connections-right-empty">


### PR DESCRIPTION
## Description

This PR connects the suggestSession API to the Schedule tab UI, replacing placeholders with actual suggested time slots.

### Context
- Called the `suggestSession` API function in the Connections Page component and passed the results down as props to the **Schedule** component.
- Replaced the previous placeholder with a layout that dynamically displays suggested meeting times to the user.

### Future PRs
- Completing all remaining iterations regarding the frontend and backend aspects.
- Getting the total upcoming sessions. 
- Implementing the functionality of the **Task** tab.

## Milestones
This PR completes the frontend UI part of the technical challenge as it displays the suggested times to meet to a user.

## Test Plan
Testing plan is still ongoing and algorithm is till being finalized
These are results from results or previous algorithms.
### Test Artifacts
<img width="1728" height="1023" alt="Screenshot 2025-07-22 at 3 59 04 AM" src="https://github.com/user-attachments/assets/b4bea2af-9566-4898-8904-ea0faecfa35d" />
