### PR TITLE
Changes for PR#43: Updating Error Object Passed to JSON Response

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -37,7 +37,7 @@ const signup = async (req, res) => {
         res.status(201).json({ message: "Successfully Signed Up!" });
 
     } catch (err) {
-        res.status(500).json({ error: "Something went wrong signing up" }, err);
+        res.status(500).json({ error: "Something went wrong signing up", details: err.message });
     }
 }
 
@@ -57,7 +57,7 @@ const login = async (req, res) => {
 
         res.json({ message: "Login successful", user: { id: req.session.userId, email: user.email, role: user.role } });
     } catch (err) {
-        res.status(500).json({ error: "Something went wrong logging in" }, err);
+        res.status(500).json({ error: "Something went wrong logging in", details: err.message });
     }
 }
 
@@ -72,7 +72,7 @@ const isLoggedIn = async (req, res) => {
 
         res.json({ id: req.session.userId, email: user.email, role: user.role });
     } catch (err) {
-        res.status(500).json({ error: "Try logging in again!" }, err);
+        res.status(500).json({ error: "Try logging in again!", details: err.message });
     }
 }
 
@@ -83,7 +83,7 @@ const logout = (req, res) => {
             res.json({ message: "See you next time!" })
         });
     } catch (err) {
-        res.status(500).json({ error: "Failed to log out" }, err)
+        res.status(500).json({ error: "Failed to log out", details: err.message })
     }
 }
 

--- a/backend/controllers/interestController.js
+++ b/backend/controllers/interestController.js
@@ -9,7 +9,7 @@ const getInterests = async (req, res) => {
         res.status(200).json(cachedInterest);
 
     } catch(err) {
-        res.status(500).json({ error: "Error getting interests" }, err)
+        res.status(500).json({ error: "Error getting interests", details: err.message })
     }
 }
 

--- a/backend/controllers/menteeController.js
+++ b/backend/controllers/menteeController.js
@@ -13,7 +13,7 @@ const getMentors = async (req, res) => {
         });
         res.json(mentors);
     } catch (err) {
-        res.status(404).json({ error: "No mentor found, try again later!" }, err);
+        res.status(404).json({ error: "No mentor found, try again later!", details: err.message });
     }
 }
 
@@ -26,7 +26,7 @@ const pendingRequests = async (req, res) => {
         })
         res.status(201).json(pending);
     } catch (err) {
-        res.status(404).json({ error: "No pending requests" }, err);
+        res.status(404).json({ error: "No pending requests", details: err.message });
     }
 }
 
@@ -38,7 +38,7 @@ const removeRequest = async (req, res) => {
         });
         res.status(204).send();
     } catch (err) {
-        res.status(404).json({ error: "Error removing request" }, err);
+        res.status(404).json({ error: "Error removing request", details: err.message });
     }
 }
 

--- a/backend/controllers/mentorController.js
+++ b/backend/controllers/mentorController.js
@@ -10,7 +10,7 @@ const getMenteeRequests = async (req, res) => {
         })
         res.status(201).json(requests);
     } catch (err) {
-        res.status(404).json({ error: "No requests for you" }, err);
+        res.status(404).json({ error: "No requests for you", details: err.message });
     }
 }
 

--- a/backend/controllers/mentorshipController.js
+++ b/backend/controllers/mentorshipController.js
@@ -46,7 +46,7 @@ const createMentorship = async (req, res) => {
         const connected = await prisma.mentorship.create({ data: { menteeId, mentorId } });
         res.status(201).json(connected);
     } catch (err) {
-        res.status(404).json({ error: "Error creating a connection!" }, err);
+        res.status(404).json({ error: "Error creating a connection!", details: err.message });
     }
 }
 
@@ -59,7 +59,7 @@ const updateMentorship = async (req, res) => {
         });
         res.status(201).json(updateConnection);
     } catch (err) {
-        res.status(404).json({ error: "Error updating connection!" }, err);
+        res.status(404).json({ error: "Error updating connection!", details: err.message });
     }
 }
 
@@ -87,7 +87,7 @@ const endMentorship = async (req, res) => {
         }
         res.status(204).send();
     } catch (err) {
-        res.status(404).json({ error: "Error ending connection" }, err);
+        res.status(404).json({ error: "Error ending connection", details: err.message });
     }
 }
 
@@ -100,7 +100,7 @@ const requestConnection = async (req, res) => {
         });
         res.status(201).json(request);
     } catch (err) {
-        res.status(404).json({ error: "Error sending request!" }, err);
+        res.status(404).json({ error: "Error sending request!", details: err.message });
     }
 }
 
@@ -113,7 +113,7 @@ const updateRequestStatus = async (req, res) => {
         });
         res.status(201).json(updateRequest);
     } catch (err) {
-        res.status(404).json({ error: "Error responding to request!" }, err);
+        res.status(404).json({ error: "Error responding to request!", details: err.message });
     }
 }
 

--- a/backend/controllers/recommendController.js
+++ b/backend/controllers/recommendController.js
@@ -104,7 +104,7 @@ const mentorRecomendations = async (req, res) => {
         res.status(200).json(topMentors);
 
     } catch (err) {
-        res.status(404).json({ error: "Error getting recommendations" }, err);
+        res.status(404).json({ error: "Error getting recommendations", details: err.message });
     }
 }
 

--- a/backend/controllers/schedule.controller.js
+++ b/backend/controllers/schedule.controller.js
@@ -14,13 +14,13 @@ const createSession = async (req, res) => {
         })
         res.status(201).json(session)
     } catch (err) {
-        res.status(500).json({ error: "Error creating a session" }, err)
+        res.status(500).json({ error: "Error creating a session", details: err.message })
     }
 }
 
 const removeSession = async (req, res) => {
     const sessionId = parseInt(req.params.sessionId);
-    if (Number.isNaN(mentorshipId)) {
+    if (Number.isNaN(sessionId)) {
         return res.status(400).json({ error: "Session ID is not a number" });
     }
     try {
@@ -29,7 +29,7 @@ const removeSession = async (req, res) => {
         });
         res.status(200).send();
     } catch (err) {
-        res.status(404).json({ error: "Error removing session" }, err);
+        res.status(404).json({ error: "Error removing session", details: err.message });
     }
 }
 
@@ -53,11 +53,11 @@ const sessionsHistory = async (req, res) => {
         });
         res.status(200).json(pastSessions);
     } catch (err) {
-        res.status(500).json({ error: "Error getting sessions history" }, err);
+        res.status(500).json({ error: "Error getting sessions history", details: err.message });
     }
 }
 
-const upComingSessions = async (req, res) => {
+const upcomingSessions = async (req, res) => {
     const mentorshipId = parseInt(req.params.mentorshipId);
     if (Number.isNaN(mentorshipId)) {
         return res.status(400).json({ error: "Mentorship ID not a number" });
@@ -77,7 +77,7 @@ const upComingSessions = async (req, res) => {
         })
         res.status(200).json(upcomings);
     } catch(err) {
-        res.status(500).json({ error: "Error getting upcoming session" }, err);
+        res.status(500).json({ error: "Error getting upcoming session", details: err.message });
     }
 }
 
@@ -85,5 +85,5 @@ module.exports = {
     createSession,
     removeSession,
     sessionsHistory,
-    upComingSessions
+    upcomingSessions
 }

--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -74,7 +74,7 @@ const suggestSession = async (req, res) => {
         res.status(404).json({ message: "No available time found" });
 
     } catch (err) {
-        res.status(500).json({ error: "Something went wrong!" }, err);
+        res.status(500).json({ error: "Something went wrong!", details: err.message });
     }
 }
 

--- a/backend/routes/mentorshipRoutes.js
+++ b/backend/routes/mentorshipRoutes.js
@@ -6,7 +6,7 @@ const isAuthenticated = require('../middlewares/isAuthenticated');
 const mentorRecomendations = require('../controllers/recommendController');
 const suggestSession = require('../controllers/sessionController');
 const { getInterests } = require('../controllers/interestController');
-const { createSession, removeSession, sessionsHistory, upComingSessions } = require('../controllers/schedule.controller');
+const { createSession, removeSession, sessionsHistory, upcomingSessions } = require('../controllers/schedule.controller');
 
 router.get('/mentee/home', isAuthenticated, getMentors);
 router.get('/connections', isAuthenticated, getAllConnections);
@@ -24,7 +24,7 @@ router.get('/interests', isAuthenticated, getInterests);
 router.post('/session', isAuthenticated, createSession);
 router.delete('/remove/session/:sessionId', isAuthenticated, removeSession);
 router.get('/session/past/:mentorshipId', isAuthenticated, sessionsHistory);
-router.get('/session/upcoming/:mentorshipId', isAuthenticated, upComingSessions);
+router.get('/session/upcoming/:mentorshipId', isAuthenticated, upcomingSessions);
 
 
 


### PR DESCRIPTION
## What Changed

This PR make the requested changes to [PR#43](https://github.com/MetaU-
projects/FinMind/pull/43)
It includes removing the `err` object caught from when the `try` block fails and instead making the response json return a single object that now includes the error message from the `err` object.

### How I made the change
In all instance of the error handling on backend, I added a new property `details: err.message`
