### PR TITLE
Implemented Smart Rescheduling Suggestions After Cancellation Session is Deleted

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -9,8 +9,8 @@ const suggestSession = async (req, res) => {
     const mentorId = parseInt(req.params.mentorId);
 
     if (Number.isNaN(mentorId)) {
-        return res.status(400).json({ error: "Mentor Id a number" });
-    }    
+        return res.status(400).json({ error: "MentorId is not a number" });
+    }
     try {
         const user = await prisma.mentorship.findMany({
             where: { menteeId },

--- a/backend/prisma/migrations/20250724104711_add_cancelable_to_session/migration.sql
+++ b/backend/prisma/migrations/20250724104711_add_cancelable_to_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "cancelable" BOOLEAN NOT NULL DEFAULT true;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,6 +95,7 @@ model Session {
   reason             String?
   startTime          Int
   endTime            Int
+  cancelable         Boolean    @default(true)
 }
 
 model Task {

--- a/backend/utils/freeSelfTime.js
+++ b/backend/utils/freeSelfTime.js
@@ -1,0 +1,115 @@
+const prisma = require("../config/prismaClient");
+const { getAvailability, getSessions, getFreeSlots } = require("./scheduleHelpers");
+const { oneHourIntervals } = require("./schedulingUtils");
+const { Role } = require('./statusEnums')
+
+/**
+ * This function is used to return list of overlapping time ranges between 
+ * @param {Array<[Number, Number]>} slots List of user's available slots
+ * @param {Array} param1 - Array of free time ie the cancelled session.
+ * @returns {boolean}
+ */
+
+const overlaps = (slots, [start, end]) => {
+    return slots.some(([s, e]) => s <= start && e >= end);
+}
+
+const userCache = new Map();
+/**
+ * Function to get user's free slots from once using their Ids.
+ * 
+ * @param {Number} userId - User's Id
+ * @returns {Object} - User's mapped data
+ */
+
+const loadUserData = async (userId) => {
+    if (!userCache.has(userId)) {
+        const user = await prisma.mentorship.findMany({
+            where: {
+                OR: [
+                    { mentorId: userId },
+                    { menteeId: userId }
+                ]
+            },
+            select: { mentorshipSession: true }
+        });
+        const availability = await prisma.availability.findMany({
+            where: { userId },
+            select: {
+                id: true,
+                day: true,
+                startTime: true,
+                endTime: true
+            }
+        });
+
+        userCache.set(userId, {
+            freeSlots: oneHourIntervals(getFreeSlots(getAvailability(availability), getSessions(user)))
+        });
+    }
+    return userCache.get(userId);
+}
+
+/**
+ * This function suggests users to reschedule with another mentor using a newly freed time slot.
+ * @param {Object} params - The parameters object
+ * @param {Number} params.userId - The ID of the user who cancelled the session.
+ * @param {Number} params.startTime - The start time of the cancelled session ie freed time (Unix time).
+ * @param {Number} params.endTime - The end time of the cancelled session ie freed time (Unix time)
+ * @param {Number} params.otherUserId - The ID of the partner session was cancelled.
+ * 
+ * @returns {Array<{Object}>} - List of suggested reschedule options.
+ */
+
+const suggestFromFreedTime = async ({ userId, startTime, endTime, otherUserId }) => {
+    const freedSlot = [startTime, endTime]
+
+    const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { role: true }
+    });
+
+    if (!user) return [];
+
+    const isMentee = user.role === Role.MENTEE;
+
+    const mentorships = await prisma.mentorship.findMany({
+        where: isMentee ? { menteeId: userId } : { mentorId: userId },
+        include: {
+            mentor: true,
+            mentee: true,
+        },
+    });
+
+    const suggestions = [];
+    let result;
+    for (const mentorship of mentorships) {
+        const partner = isMentee ? mentorship.mentor : mentorship.mentee;
+
+        if (partner.id === otherUserId) continue;
+
+        const userData = await loadUserData(userId);
+        const partnerData = await loadUserData(partner.id);
+
+        const userFree = userData.freeSlots;
+        const partnerFree = partnerData.freeSlots;
+
+        const userCanUse = overlaps(userFree, freedSlot);
+        const mentorCanUse = overlaps(partnerFree, freedSlot);
+
+        result = mentorCanUse
+
+        if (!userCanUse || !mentorCanUse) continue;
+
+        suggestions.push({
+            connectionId: mentorship.id,
+            name: partner.name,
+            withUser: partner.id,
+            suggesteTime: freedSlot
+        })
+    }
+
+    return suggestions;
+}
+
+module.exports = { suggestFromFreedTime }

--- a/backend/utils/schedulingUtils.js
+++ b/backend/utils/schedulingUtils.js
@@ -45,21 +45,23 @@ const timeOverlaps = (menteeSlots, mentorSlots) => {
  * 
  * @param {[string, string]} avail - The availability interval
  * @param {Array<[Number, Number]>} sessions - The existing session to subtract
- * @returns {Array<[Number, Number]>} - Free times
+ * @returns {Array<[Number, Number]>} - Free tğmes
  * 
  */
 
 const subtractInterval = (preference, sessions) => {
     let result = [];
-    let start = preference[0];
-    for (let session of sessions) {
-        if (start < session[0]) {
-            result.push([start, session[0]]);
+    let [start, end] = preference;
+    let currentStart = start
+    for (const [sessStart, sessEnd] of sessions) {
+        if (sessStart > currentStart) {
+            result.push([currentStart, Math.min(sessStart, end)]);
         }
-        if (start < session[1]) start = session[1];
+        currentStart = Math.max(currentStart, sessEnd);
+        if (currentStart >= end) break;
     }
-    if (start < preference[1]) {
-        result.push([start, preference[1]]);
+    if (start < end) {
+        result.push([currentStart, end]);
     }
     return result;
 }

--- a/frontend/src/components/ConnectionsComp/Schedule.jsx
+++ b/frontend/src/components/ConnectionsComp/Schedule.jsx
@@ -100,17 +100,13 @@ export default function Schedule({ connection, timeSuggestions, update }) {
                                 <h3>Cancel<strong>{formatUnixTimes(timeSuggestions.resolvedSession.freedTime[0], timeSuggestions.resolvedSession.freedTime[1])}</strong></h3>
                             </div>
                             <h3>Rescheduling Option</h3>
-                            {timeSuggestions.resolvedSession.rescheduleTo.map(session => {
                                 <div className="session">
                                     <div className="time">
                                         <AiOutlineClockCircle />
-                                        <h3><strong>{formatUnixTimes(session[0], session[1])}</strong></h3>
+                                        <h3><strong>{formatUnixTimes(timeSuggestions.resolvedSession.rescheduleTo[0], timeSuggestions.resolvedSession.rescheduleTo[1])}</strong></h3>
                                     </div>
                                 </div>
-                            })
-                            }
                         </div>
-
                     )}
                 </div>
             </div>


### PR DESCRIPTION
## Description

This PR implements backend logic that, upon canceling a session marked as cancelable, checks if the now-freed time slot can be reused by the canceling user with any of their existing mentorship connections. The system suggest available mentorship connections. The system suggests available connections (excluding the one just canceled with) that share mutal availability for that same time.

**Refereces**: [Project Process Details](https://docs.google.com/document/d/1IS9PjGo6bTUraB12VwymkuySsonx-MDjSDm_PT7BrwI/edit?tab=t.0#heading=h.ifvl8ma0rodg), [Pseudocode Details](https://docs.google.com/document/d/1ew0g3b10RClzVz05v5e4IEjV8hw1yuFBJ5iMNklhwQA/edit?tab=t.0#heading=h.d1ltjg3y8pcj)

### Context
- Introduces a cancellable boolean field on the Session model (default: true).
- Updated the DELETE /:sesionId logic to:
   - Identify the canceling user
   - Determine the other party in the session.
   - Call a new `suggestFromFreedTime` function after deletion, if cancelable.
- The suggestion function:
   - Pulls all mentor/mentee connections for the user
   - Uses `getFreeSlots` to calculate true availability (availability - sessions)
   - Checks who can use the freed slot and filters out the user who was just canceled on.
   - Returns suggestion results to the frontend.
- Updated the functions like `subtractInterval` and `resolveConflict` to return appropriate result. 

### Future PRs
- Implement frontend UI to display these reschedule suggestions after a session is canceled.

## Milestones
This PR works towards the completion of iterations on the second technical challenge which is building scheduling system. 

## Test Plan
- Created a session between a mentor and mentee. 
- Deleted the session
- **Expected Result**: Suggestion of anther mentor free at the cancelled time.
- Cancelled time : 07/25/2025 3:00 - 5:00

### Test Artifact
The following image shows the deletion of a session and the result is a suggestion to meet with an available user at that time.

<img width="1439" height="429" alt="Screenshot 2025-07-24 at 1 03 22 PM" src="https://github.com/user-attachments/assets/3f65b8a6-5879-4d03-8785-8c496d7ef3b2" />
